### PR TITLE
cmake(bugfix):fix JIDL target intermediate products override issue

### DIFF
--- a/cmake/nuttx_add_jidl.cmake
+++ b/cmake/nuttx_add_jidl.cmake
@@ -87,6 +87,12 @@ function(nuttx_add_jidl)
       COMMENT "JIDL: generating glue files for ${JIDL_NAME}.jidl")
 
     add_dependencies(${TARGET} ${JIDL_TARGET})
+    # make a link list dep of jidl targets
+    get_property(DEP_JIDL_TARGET GLOBAL PROPERTY GLOBAL_JIDL_TARGET)
+    if(DEP_JIDL_TARGET)
+      add_dependencies(${JIDL_TARGET} ${DEP_JIDL_TARGET})
+    endif()
+    set_property(GLOBAL PROPERTY GLOBAL_JIDL_TARGET ${JIDL_TARGET})
     target_sources(${TARGET} PRIVATE ${JIDL_SRC})
   endforeach()
 


### PR DESCRIPTION
## Summary

fix JIDL target intermediate products override

## Impact

bugfix

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela--cmake 

```


