### PR TITLE
cmake(build):add benchmarks osperf CMakeLists.txt

### DIFF
--- a/benchmarks/osperf/CMakeLists.txt
+++ b/benchmarks/osperf/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ##############################################################################
+# apps/benchmarks/osperf/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_BENCHMARK_OSPERF)
+  nuttx_add_application(
+    NAME
+    osperf
+    SRCS
+    osperf.c
+    STACKSIZE
+    ${CONFIG_BENCHMARK_OSPERF_STACKSIZE}
+    PRIORITY
+    ${CONFIG_BENCHMARK_OSPERF_PRIORITY})
+endif()


### PR DESCRIPTION
## Summary

add benchmarks osperf cmake support

## Impact

new feat

## Testing

```
./build.sh vendor/sim/boards/vela/configs/vela--cmake 

```


