### PR TITLE
nshlib/cmd_cat: Retry if nsh_read was interrupted by a signal

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -802,8 +802,17 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
       while (true)
         {
           ret = nsh_read(vtbl, buf, BUFSIZ);
-          if (ret <= 0)
+          if (ret == 0)
             {
+              break;
+            }
+          else if (ret < 0)
+            {
+              if (errno == EINTR)
+                {
+                  continue;
+                }
+
               break;
             }
 


### PR DESCRIPTION
## Summary
nshlib/cmd_cat: Retry if `nsh_read()` was interrupted by a signal.
When read from stdio of child process through pipe, SIGCHLD received if child exits.

## Impact
nshlib/cmd_cat.

## Testing
1. Selftest
```
ls | cat | cat | cat | cat
```
2. Github CI
