### PR TITLE
Add pipeline support for nsh commandline

### DIFF
--- a/builtin/exec_builtin.c
+++ b/builtin/exec_builtin.c
@@ -158,6 +158,19 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
               goto errout_with_actions;
             }
         }
+#ifdef CONFIG_NSH_PIPELINE
+      else if (param->fd_in != -1)
+        {
+          ret = posix_spawn_file_actions_adddup2(&file_actions,
+                                                 param->fd_in, 0);
+          if (ret != 0)
+            {
+              serr("ERROR: posix_spawn_file_actions_adddup2 failed: %d\n",
+                   ret);
+              goto errout_with_actions;
+            }
+        }
+#endif
 
       /* Is output being redirected? */
 
@@ -175,6 +188,19 @@ int exec_builtin(FAR const char *appname, FAR char * const *argv,
               goto errout_with_actions;
             }
         }
+#ifdef CONFIG_NSH_PIPELINE
+      else if (param->fd_out != -1)
+        {
+          ret = posix_spawn_file_actions_adddup2(&file_actions,
+                                                 param->fd_out, 1);
+          if (ret != 0)
+            {
+              serr("ERROR: posix_spawn_file_actions_adddup2 failed: %d\n",
+                   ret);
+              goto errout_with_actions;
+            }
+        }
+#endif
     }
 
 #ifdef CONFIG_LIBC_EXECFUNCS

--- a/include/builtin/builtin.h
+++ b/include/builtin/builtin.h
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 
 #include <nuttx/lib/builtin.h>
+#include <nshlib/nshlib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -66,13 +67,7 @@ extern "C"
  * Input Parameter:
  *   filename      - Name of the linked-in binary to be started.
  *   argv          - Argument list
- *   redirfile_in  - If input is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   redirfile_out - If output is redirected, this parameter will be non-NULL
- *                   and will provide the full path to the file.
- *   oflags        - If output is redirected, this parameter will provide the
- *                   open flags to use.  This will support file replacement
- *                   of appending to an existing file.
+ *   param         - Parameters for execute.
  *
  * Returned Value:
  *   This is an end-user function, so it follows the normal convention:
@@ -82,8 +77,7 @@ extern "C"
  ****************************************************************************/
 
 int exec_builtin(FAR const char *appname, FAR char * const *argv,
-                 FAR const char *redirfile_in, FAR const char *redirfile_out,
-                 int oflags);
+                 FAR const struct nsh_param_s *param);
 
 #undef EXTERN
 #if defined(__cplusplus)

--- a/include/nshlib/nshlib.h
+++ b/include/nshlib/nshlib.h
@@ -65,6 +65,25 @@
 #  define SCHED_NSH SCHED_FIFO
 #endif
 
+struct nsh_param_s
+{
+  /* Redirect input/output through `fd` OR `path_name`
+   *
+   * Select one:
+   * 1. Using fd_in/fd_out as oldfd for dup2() if greater than -1.
+   * 2. Using file_in/file_out as full path to the file if it is
+   *    not NULL, and oflags_in/oflags_out as flags for open().
+   */
+
+  int fd_in;
+  int fd_out;
+
+  int oflags_in;
+  int oflags_out;
+  FAR const char *file_in;
+  FAR const char *file_out;
+};
+
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -231,6 +231,13 @@ config NSH_ALIAS_MAX_AMOUNT
 
 endif # NSH_ALIAS
 
+config NSH_PIPELINE
+	bool "Enable pipeline support"
+	default !DEFAULT_SMALL
+	depends on PIPES
+	---help---
+		Enable pipeline support for nsh.
+
 endmenu # Command Line Configuration
 
 config NSH_BUILTIN_APPS

--- a/nshlib/nsh.h
+++ b/nshlib/nsh.h
@@ -39,6 +39,7 @@
 #endif
 
 #include <nuttx/usb/usbdev_trace.h>
+#include <nshlib/nshlib.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -858,14 +859,12 @@ int nsh_command(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char *argv[]);
 
 #ifdef CONFIG_NSH_BUILTIN_APPS
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags);
+                FAR char **argv, FAR const struct nsh_param_s *param);
 #endif
 
 #ifdef CONFIG_NSH_FILE_APPS
 int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags);
+                FAR char **argv, FAR const struct nsh_param_s *param);
 #endif
 
 #ifndef CONFIG_DISABLE_ENVIRON

--- a/nshlib/nsh_builtin.c
+++ b/nshlib/nsh_builtin.c
@@ -69,8 +69,8 @@
  ****************************************************************************/
 
 int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
-                FAR char **argv, FAR const char *redirfile_in,
-                FAR const char *redirfile_out, int oflags)
+                FAR char **argv,
+                FAR const struct nsh_param_s *param)
 {
 #if !defined(CONFIG_NSH_DISABLEBG) && defined(CONFIG_SCHED_CHILD_STATUS)
   struct sigaction act;
@@ -102,7 +102,7 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
    * applications.
    */
 
-  ret = exec_builtin(cmd, argv, redirfile_in, redirfile_out, oflags);
+  ret = exec_builtin(cmd, argv, param);
   if (ret >= 0)
     {
       /* The application was successfully started with pre-emption disabled.
@@ -234,9 +234,9 @@ int nsh_builtin(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
 
           sigaction(SIGCHLD, &old, NULL);
 #  endif
-          struct sched_param param;
-          sched_getparam(ret, &param);
-          nsh_output(vtbl, "%s [%d:%d]\n", cmd, ret, param.sched_priority);
+          struct sched_param sched;
+          sched_getparam(ret, &sched);
+          nsh_output(vtbl, "%s [%d:%d]\n", cmd, ret, sched.sched_priority);
 
           /* Backgrounded commands always 'succeed' as long as we can start
            * them.

--- a/nshlib/nsh_fileapps.c
+++ b/nshlib/nsh_fileapps.c
@@ -126,6 +126,20 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
               goto errout_with_actions;
             }
         }
+#ifdef CONFIG_NSH_PIPELINE
+      else if (param->fd_in != -1)
+        {
+          ret = posix_spawn_file_actions_adddup2(&file_actions,
+                                                 param->fd_in, 0);
+          if (ret != 0)
+            {
+              nsh_error(vtbl, g_fmtcmdfailed, cmd,
+                        "posix_spawn_file_actions_adddup2",
+                        NSH_ERRNO);
+              goto errout_with_actions;
+            }
+        }
+#endif
 
       /* Handle re-direction of output */
 
@@ -147,6 +161,20 @@ int nsh_fileapp(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
               goto errout_with_attrs;
             }
         }
+#ifdef CONFIG_NSH_PIPELINE
+      else if (param->fd_out != -1)
+        {
+          ret = posix_spawn_file_actions_adddup2(&file_actions,
+                                                 param->fd_out, 1);
+          if (ret != 0)
+            {
+              nsh_error(vtbl, g_fmtcmdfailed, cmd,
+                        "posix_spawn_file_actions_adddup2",
+                        NSH_ERRNO);
+              goto errout_with_actions;
+            }
+        }
+#endif
     }
 
 #ifdef CONFIG_BUILTIN

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -248,28 +248,32 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline);
  * Private Data
  ****************************************************************************/
 
-static const char g_token_separator[] = " \t\n";
-static const char g_quote_separator[] = "'\"`";
+static const char   g_token_separator[] = " \t\n";
+static const char   g_quote_separator[] = "'\"`";
 #ifndef NSH_DISABLE_SEMICOLON
-static const char g_line_separator[]  = "\"'#;\n";
+static const char   g_line_separator[]  = "\"'#;\n";
 #endif
 #ifdef CONFIG_NSH_ARGCAT
-static const char g_arg_separator[]   = "`$";
+static const char   g_arg_separator[]   = "`$";
 #endif
-static const char g_redirect_out1[]   = ">";
-static const char g_redirect_out2[]  = ">>";
-static const char g_redirect_in1[]   = "<";
+static const char   g_redirect_out1[]   = ">";
+static const size_t g_redirect_out1_len = sizeof(g_redirect_out1) - 1;
+static const char   g_redirect_out2[]   = ">>";
+static const size_t g_redirect_out2_len = sizeof(g_redirect_out2) - 1;
+static const char   g_redirect_in1[]    = "<";
+static const size_t g_redirect_in1_len  = sizeof(g_redirect_in1) - 1;
 #ifdef CONFIG_NSH_PIPELINE
-static const char g_pipeline1[]       = "|";
+static const char   g_pipeline1[]       = "|";
+static const size_t g_pipeline1_len     = sizeof(g_pipeline1) - 1;
 #endif
 #ifdef NSH_HAVE_VARS
-static const char g_exitstatus[]      = "?";
-static const char g_lastpid[]         = "!";
-static const char g_success[]         = "0";
-static const char g_failure[]         = "1";
+static const char   g_exitstatus[]      = "?";
+static const char   g_lastpid[]         = "!";
+static const char   g_success[]         = "0";
+static const char   g_failure[]         = "1";
 #endif
 #ifdef NEED_NULLSTRING
-static const char g_nullstring[]      = "";
+static const char   g_nullstring[]      = "";
 #endif
 
 /****************************************************************************
@@ -2447,12 +2451,6 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 #ifdef CONFIG_NSH_PIPELINE
   bool      bg_save = false;
 #endif
-  size_t redirect_out1_len = strlen(g_redirect_out1);
-  size_t redirect_out2_len = strlen(g_redirect_out2);
-  size_t redirect_in1_len = strlen(g_redirect_in1);
-#ifdef CONFIG_NSH_PIPELINE
-  size_t pipeline1_len = strlen(g_pipeline1);
-#endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
   char      tracebuf[CONFIG_NSH_LINELEN + 1];
@@ -2601,12 +2599,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
             }
         }
 
-      if (!strncmp(argv[argc], g_redirect_out2, redirect_out2_len))
+      if (!strncmp(argv[argc], g_redirect_out2, g_redirect_out2_len))
         {
           FAR char *arg;
-          if (argv[argc][redirect_out2_len])
+          if (argv[argc][g_redirect_out2_len])
             {
-              arg = &argv[argc][redirect_out2_len];
+              arg = &argv[argc][g_redirect_out2_len];
             }
           else
             {
@@ -2625,12 +2623,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           param.oflags_out      = O_WRONLY | O_CREAT | O_APPEND;
           param.file_out        = nsh_getfullpath(vtbl, arg);
         }
-      else if (!strncmp(argv[argc], g_redirect_out1, redirect_out1_len))
+      else if (!strncmp(argv[argc], g_redirect_out1, g_redirect_out1_len))
         {
           FAR char *arg;
-          if (argv[argc][redirect_out1_len])
+          if (argv[argc][g_redirect_out1_len])
             {
-              arg = &argv[argc][redirect_out1_len];
+              arg = &argv[argc][g_redirect_out1_len];
             }
           else
             {
@@ -2649,12 +2647,12 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           param.oflags_out      = O_WRONLY | O_CREAT | O_TRUNC;
           param.file_out        = nsh_getfullpath(vtbl, arg);
         }
-      else if (!strncmp(argv[argc], g_redirect_in1, redirect_in1_len))
+      else if (!strncmp(argv[argc], g_redirect_in1, g_redirect_in1_len))
         {
           FAR char *arg;
-          if (argv[argc][redirect_in1_len])
+          if (argv[argc][g_redirect_in1_len])
             {
-              arg = &argv[argc][redirect_in1_len];
+              arg = &argv[argc][g_redirect_in1_len];
             }
           else
             {
@@ -2674,14 +2672,14 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           param.file_in         = nsh_getfullpath(vtbl, arg);
         }
 #ifdef CONFIG_NSH_PIPELINE
-      else if (!strncmp(argv[argc], g_pipeline1, pipeline1_len))
+      else if (!strncmp(argv[argc], g_pipeline1, g_pipeline1_len))
         {
           FAR char *arg;
           FAR char *sh_argv[4];
 
-          if (argv[argc][pipeline1_len])
+          if (argv[argc][g_pipeline1_len])
             {
-              arg = &argv[argc][pipeline1_len];
+              arg = &argv[argc][g_pipeline1_len];
             }
           else
             {

--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -259,6 +259,9 @@ static const char g_arg_separator[]   = "`$";
 static const char g_redirect_out1[]   = ">";
 static const char g_redirect_out2[]  = ">>";
 static const char g_redirect_in1[]   = "<";
+#ifdef CONFIG_NSH_PIPELINE
+static const char g_pipeline1[]       = "|";
+#endif
 #ifdef NSH_HAVE_VARS
 static const char g_exitstatus[]      = "?";
 static const char g_lastpid[]         = "!";
@@ -1601,6 +1604,16 @@ static FAR char *nsh_argument(FAR struct nsh_vtbl_s *vtbl,
       argument = (FAR char *)g_redirect_in1;
     }
 
+#ifdef CONFIG_NSH_PIPELINE
+  /* Does the token begin with '|' -- pipeline? */
+
+  if (*pbegin == '|')
+    {
+      *saveptr = pbegin + 1;
+      argument = (FAR char *)g_pipeline1;
+    }
+#endif
+
   /* Does the token begin with '#' -- comment */
 
   else if (*pbegin == '#')
@@ -2415,6 +2428,13 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       .file_out   = NULL
     };
 
+#ifdef CONFIG_NSH_PIPELINE
+  int pipefd[2] =
+    {
+      -1, -1
+    };
+#endif
+
   NSH_MEMLIST_TYPE memlist;
   NSH_ALIASLIST_TYPE alist;
   FAR char *argv[MAX_ARGV_ENTRIES];
@@ -2424,9 +2444,15 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
   int       ret;
   bool      redirect_out_save = false;
   bool      redirect_in_save = false;
+#ifdef CONFIG_NSH_PIPELINE
+  bool      bg_save = false;
+#endif
   size_t redirect_out1_len = strlen(g_redirect_out1);
   size_t redirect_out2_len = strlen(g_redirect_out2);
   size_t redirect_in1_len = strlen(g_redirect_in1);
+#ifdef CONFIG_NSH_PIPELINE
+  size_t pipeline1_len = strlen(g_pipeline1);
+#endif
 
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP
   char      tracebuf[CONFIG_NSH_LINELEN + 1];
@@ -2647,6 +2673,89 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
           param.oflags_in       = O_RDONLY;
           param.file_in         = nsh_getfullpath(vtbl, arg);
         }
+#ifdef CONFIG_NSH_PIPELINE
+      else if (!strncmp(argv[argc], g_pipeline1, pipeline1_len))
+        {
+          FAR char *arg;
+          FAR char *sh_argv[4];
+
+          if (argv[argc][pipeline1_len])
+            {
+              arg = &argv[argc][pipeline1_len];
+            }
+          else
+            {
+              arg = nsh_argument(vtbl, &saveptr, &memlist, NULL, &isenvvar);
+            }
+
+          if (!arg)
+            {
+              nsh_error(vtbl, g_fmtarginvalid, cmd);
+              ret = ERROR;
+              goto dynlist_free;
+            }
+
+          for (ret = 0; ret < argc - 1; ret++)
+            {
+              FAR char *p_arg = argv[ret];
+              size_t len = strlen(p_arg);
+
+              /* Restore from split args to concat args. */
+
+              DEBUGASSERT(&p_arg[len + 1] == argv[ret + 1]);
+              p_arg[len] = ' ';
+            }
+
+          sh_argv[0] = "sh";
+          sh_argv[1] = "-c";
+          sh_argv[2] = argv[0];
+          sh_argv[3] = NULL;
+
+          ret = pipe2(pipefd, 0);
+          if (ret < 0)
+            {
+              ret = -errno;
+              goto dynlist_free;
+            }
+
+          redirect_out_save = vtbl->np.np_redir_out;
+          vtbl->np.np_redir_out = true;
+          param.fd_out = pipefd[1];
+
+          bg_save = vtbl->np.np_bg;
+          vtbl->np.np_bg = true;
+
+          ret = nsh_execute(vtbl, 4, sh_argv, &param);
+
+          vtbl->np.np_bg = bg_save;
+
+          if (param.fd_in != -1)
+            {
+              close(param.fd_in);
+              param.fd_in = -1;
+              vtbl->np.np_redir_in = redirect_in_save;
+            }
+
+          if (param.fd_out != -1)
+            {
+              close(param.fd_out);
+              param.fd_out = -1;
+              vtbl->np.np_redir_out = redirect_out_save;
+            }
+
+          redirect_in_save = vtbl->np.np_redir_in;
+          vtbl->np.np_redir_in = true;
+          param.fd_in = pipefd[0];
+
+          argv[0] = arg;
+          argc = 1;
+
+          if (ret == -1)
+            {
+              goto dynlist_free;
+            }
+        }
+#endif
       else
         {
           argc++;
@@ -2678,6 +2787,8 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
 
   ret = nsh_execute(vtbl, argc, argv, &param);
 
+dynlist_free:
+
   /* Free any allocated resources */
 
   /* Free the redirected output file path */
@@ -2687,6 +2798,13 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       nsh_freefullpath((char *)param.file_out);
       vtbl->np.np_redir_out = redirect_out_save;
     }
+#ifdef CONFIG_NSH_PIPELINE
+  else if (param.fd_out != -1)
+    {
+      close(param.fd_out);
+      vtbl->np.np_redir_out = redirect_out_save;
+    }
+#endif
 
   /* Free the redirected input file path */
 
@@ -2695,8 +2813,14 @@ static int nsh_parse_command(FAR struct nsh_vtbl_s *vtbl, FAR char *cmdline)
       nsh_freefullpath((char *)param.file_in);
       vtbl->np.np_redir_in = redirect_in_save;
     }
+#ifdef CONFIG_NSH_PIPELINE
+  else if (param.fd_in != -1)
+    {
+      close(param.fd_in);
+      vtbl->np.np_redir_in = redirect_in_save;
+    }
+#endif
 
-dynlist_free:
   NSH_ALIASLIST_FREE(vtbl, &alist);
   NSH_MEMLIST_FREE(&memlist);
 #ifdef CONFIG_SCHED_INSTRUMENTATION_DUMP

--- a/testing/cmocka/cmocka_main.c
+++ b/testing/cmocka/cmocka_main.c
@@ -198,7 +198,7 @@ int main(int argc, FAR char *argv[])
         }
 
       bypass[0] = (FAR char *)builtin->name;
-      ret = exec_builtin(builtin->name, bypass, NULL, NULL, 0);
+      ret = exec_builtin(builtin->name, bypass, NULL);
       if (ret >= 0)
         {
           waitpid(ret, &ret, WUNTRACED);


### PR DESCRIPTION
## Summary
Add pipeline support for nsh commandline through `pipe2()` and `posix_spawn_file_actions_adddup2()`
1. Pack parameters of nsh_execute() as struct nsh_exec_param_s
    - Input redirect flags currently is hardcode, passing by arguments maybe better.
    - Only support redirect to path_name, redirect to fd is needed for pipeline.
2. Add pipeline support for commandline
3. Concat variable arguments failed - [nshlib/pipeline: Concat variable arguments failed](https://github.com/open-vela/nuttx-apps/pull/18/commits/fec5af6a1e28089be4cc5b9df45c10affa80b382)
    - Without this patch
    ```
    nsh> set var_test `uname`
    nsh> echo $var_test
    NuttX
    nsh> echo $var_test | cat
    sh [5:100]
    
    nsh>
    ```
    - With this patch
    ```
    nsh> set var_test `uname`
    nsh> echo $var_test
    NuttX
    nsh> echo $var_test | cat
    sh [4:100]
    NuttX
    nsh>
    ```
    Reported by @jasonbu and @yangao1@xiaomi.com, thank you ;-)

And nesting pipeline supported.

## Impact
nsh: nsh_parse_command()

## Testing
#### General
```
# Redirectin
cat < /etc/init.d/rc.sysinit

# Pipe
ls | cat

# Pipe (nested)
ls | cat | cat | cat

# FIFO
mkfifo /dev/testfifo
cat /dev/testfifo &
ls > /dev/testfifo

# CMDPARAMS
set name `uname`
echo $name

# binfmt/sotest
sotest
```
#### With dd
Depends: https://github.com/apache/nuttx-apps/pull/2751
```bash
# Env
# sim:nsh with `PIPES`, `NSH_PIPELINE_NEST_DEPTH=5`, `FS_HOSTFS` and `SIM_HOSTFS` enabled.

# Read from stdin and write to "of" 
mount -t hostfs -o fs=. /data 
ls | cat | dd | cat | dd of=/data/test_dd_stdin

#Read from stdin and write to stdout
ls | cat | dd | cat | dd
```

- patch
```diff
$ git diff
diff --git a/nshlib/nsh_ddcmd.c b/nshlib/nsh_ddcmd.c
index 601e64408d..812d51c103 100644
--- a/nshlib/nsh_ddcmd.c
+++ b/nshlib/nsh_ddcmd.c
@@ -107,7 +107,9 @@ static int dd_write(FAR struct dd_s *dd)
   written = 0;
   do
     {
+      write(dd->outfd, "<dd ", 4);
       nbytes = write(dd->outfd, buffer, dd->nbytes - written);
+      write(dd->outfd, " dd>", 4);
       if (nbytes < 0)
         { 
           FAR struct nsh_vtbl_s *vtbl = dd->vtbl;
diff --git a/nshlib/nsh_fscmds.c b/nshlib/nsh_fscmds.c
index 413ed24634..e6a453ab5b 100644
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -806,7 +806,9 @@ int cmd_cat(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           if (n == 0)
             break;

+          nsh_write(vtbl, "<cat ", 5);
           nsh_write(vtbl, buf, n);
+          nsh_write(vtbl, " cat>", 5);
         }

       free(buf);
```
- runtime
```
nsh> ls | cat | cat | dd | dd
<dd <dd <cat <cat /:
 bin/
 data/
 dev/
 etc/
 proc/
 tmp/
 var/
 cat> cat> dd> dd>nsh>
nsh> ls | dd | cat | cat | dd
<dd <cat <cat <dd /:
 bin/
 data/
 dev/
 etc/
 proc/
 tmp/
 var/
 dd> cat cat><cat > cat> dd>nsh>
nsh>
```
#### Apache:NuttX CI