### PR TITLE
crypto/mbedtls: Add SHA-3 module

### DIFF
--- a/crypto/mbedtls/Kconfig
+++ b/crypto/mbedtls/Kconfig
@@ -529,6 +529,10 @@ config MBEDTLS_SHA512_C
 	bool "Enable SHA-512 cryptographic hash algorithms."
 	default y
 
+config MBEDTLS_SHA3_C
+	bool "Enable SHA-3 cryptographic hash algorithms."
+	default y
+
 config MBEDTLS_SSL_CACHE_C
 	bool "Enable simple SSL cache implementation."
 	default y

--- a/crypto/mbedtls/include/mbedtls/mbedtls_config.h
+++ b/crypto/mbedtls/include/mbedtls/mbedtls_config.h
@@ -3607,6 +3607,19 @@
 #endif
 
 /**
+ * \def MBEDTLS_SHA3_C
+ *
+ * Enable the SHA3 cryptographic hash algorithm.
+ *
+ * Module:  library/sha3.c
+ *
+ * This module adds support for SHA3.
+ */
+#ifdef CONFIG_MBEDTLS_SHA3_C
+#define MBEDTLS_SHA3_C
+#endif
+
+/**
  * \def MBEDTLS_SHA512_USE_A64_CRYPTO_IF_PRESENT
  *
  * Enable acceleration of the SHA-512 and SHA-384 cryptographic hash


### PR DESCRIPTION
mbedtls support sha3 module in v3.4.0