### PR TITLE
ostest/pthread_rwlock: We need to wait for race_cond_thread2 to acqui…

### DIFF
--- a/testing/ostest/pthread_rwlock.c
+++ b/testing/ostest/pthread_rwlock.c
@@ -88,6 +88,7 @@ static FAR void *race_cond_thread1(FAR void *data)
       ASSERT(false);
     }
 
+  sem_wait(rc->sem1);
   status = pthread_rwlock_rdlock(rc->rw_lock);
   if (status != 0)
     {
@@ -197,6 +198,7 @@ static FAR void *race_cond_thread2(FAR void *data)
       ASSERT(false);
     }
 
+  sem_post(rc->sem1);
   if (g_race_cond_thread_pos++ != 3)
     {
       printf("pthread_rwlock: Thread order unexpected. Expected 3, got %d",


### PR DESCRIPTION
…re the rdlock first, otherwise it may cause a deadlock.