### PR TITLE
wamr:remove CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY

### DIFF
--- a/interpreters/wamr/CMakeLists.txt
+++ b/interpreters/wamr/CMakeLists.txt
@@ -77,17 +77,23 @@ if(CONFIG_INTERPRETERS_WAMR)
     DEPENDS
     wamr)
 
-  if(CONFIG_INTERPRETERS_WAMR_LIBC_NUTTX
-     OR CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY)
-    nuttx_append_source_file_properties(
-      ${WAMR_DIR}/product-mini/platforms/nuttx/main.c COMPILE_FLAGS
-      -Dwasm_runtime_full_init=wamr_custom_init)
-    target_sources(wamr PRIVATE wamr_custom_init.c)
-  endif()
+  nuttx_append_source_file_properties(
+    ${WAMR_DIR}/product-mini/platforms/nuttx/main.c COMPILE_FLAGS
+    -Dwasm_runtime_full_init=wamr_custom_init)
+  target_sources(wamr PRIVATE wamr_custom_init.c)
+
+  set(WAMR_MODULE_LIST ${CMAKE_BINARY_DIR}/wamrmod/wamr_external_module_list.h)
+  set(WAMR_MODULE_PROTO
+      ${CMAKE_BINARY_DIR}/wamrmod/wamr_external_module_proto.h)
+
+  add_custom_target(
+    wamr_module_gen
+    COMMAND ${CMAKE_COMMAND} -E touch ${WAMR_MODULE_LIST}
+    COMMAND ${CMAKE_COMMAND} -E touch ${WAMR_MODULE_PROTO})
+
+  nuttx_add_dependencies(TARGET wamr DEPENDS wamr_module_gen)
 
   # Add ${CMAKE_BINARY_DIR}/wamrmod to the include directories
-  if(CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY)
-    target_include_directories(wamr PRIVATE ${CMAKE_BINARY_DIR}/wamrmod)
-  endif()
+  target_include_directories(wamr PRIVATE ${CMAKE_BINARY_DIR}/wamrmod)
 
 endif()

--- a/interpreters/wamr/Kconfig
+++ b/interpreters/wamr/Kconfig
@@ -248,12 +248,4 @@ config INTERPRETERS_WAMR_CONFIGUABLE_BOUNDS_CHECKS
 		disable bounds checks passing --disable-bounds-checks to
 		iwasm.
 
-config INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY
-	bool "Enable external module registry"
-	default n
-	---help---
-		This option enables the support for loading WASM modules from
-		external libraries, which is useful when you want to extend the
-		functionality of WAMR without modifying its source code.
-
 endif

--- a/interpreters/wamr/Makefile
+++ b/interpreters/wamr/Makefile
@@ -46,9 +46,7 @@ WAMR_NEED_CUSTOM_INIT = n
 
 # Check if we need to build custom init code
 
-ifeq ($(CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY),y)
 WAMR_NEED_CUSTOM_INIT = y
-endif
 
 # If we need custom init code, add it to the build
 ifeq ($(WAMR_NEED_CUSTOM_INIT),y)
@@ -69,8 +67,6 @@ $(WAMR_UNPACK): $(WAMR_TARBALL)
 	$(Q) touch $(WAMR_UNPACK)
 
 # Register the external WAMR module
-
-ifeq ($(CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY),y)
 
 PDATLIST = $(strip $(call RWILDCARD, registry, *.pdat))
 BDATLIST = $(strip $(call RWILDCARD, registry, *.bdat))
@@ -95,7 +91,6 @@ else
 endif
 
 depend:: $(GLUECSRCS) wamr_external_module_list.h wamr_external_module_proto.h
-endif # CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY
 
 clean::
 	$(call DELFILE, wamr_external_module_list.h)
@@ -104,6 +99,7 @@ clean::
 clean_context::
 	$(call DELFILE, $(BDATLIST))
 	$(call DELFILE, $(PDATLIST))
+	$(call DELFILE, registry$(DELIM).updated)
 
 # Download and unpack tarball if no git repo found
 ifeq ($(wildcard $(WAMR_UNPACK)/.git),)

--- a/interpreters/wamr/wamr_custom_init.c
+++ b/interpreters/wamr/wamr_custom_init.c
@@ -32,10 +32,7 @@
 #include <iconv.h>
 
 #include "wasm_native.h"
-
-#ifdef CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY
 #include "wamr_external_module_proto.h"
-#endif
 
 /****************************************************************************
  * Private Data
@@ -43,12 +40,10 @@
 
 typedef bool (*module_register_t)(void);
 
-#ifdef CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY
 static const module_register_t g_wamr_modules[] =
 {
 #include "wamr_external_module_list.h"
 };
-#endif
 
 /****************************************************************************
  * Public Functions
@@ -65,7 +60,6 @@ bool wamr_custom_init(RuntimeInitArgs *init_args)
 
   /* Add extra init hook here */
 
-#ifdef CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY
   for (int i = 0; i < nitems(g_wamr_modules); i++)
     {
       ret = g_wamr_modules[i]();
@@ -74,7 +68,6 @@ bool wamr_custom_init(RuntimeInitArgs *init_args)
           return ret;
         }
     }
-#endif
 
   return ret;
 }


### PR DESCRIPTION
## Summary

Remove CONFIG_INTERPRETERS_WAMR_EXTERNAL_MODULE_REGISTRY to simplify config,