### PR TITLE
testing/nettest: Added two new testcases and a set of public functions for packet capture

### DIFF
--- a/testing/nettest/CMakeLists.txt
+++ b/testing/nettest/CMakeLists.txt
@@ -33,6 +33,16 @@ if(CONFIG_TESTING_NET_TEST)
       list(APPEND SRCS ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp_connect_ipv6.c)
     endif()
 
+    if(CONFIG_NET_PKT)
+      list(APPEND SRCS ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp_connect_rst.c
+           ${CMAKE_CURRENT_LIST_DIR}/utils/nettest_netdump.c)
+
+      if(CONFIG_NET_SOLINGER)
+        list(APPEND SRCS
+             ${CMAKE_CURRENT_LIST_DIR}/tcp/test_tcp_connect_solinger.c)
+      endif()
+    endif()
+
     nuttx_add_application(
       NAME
       cmocka_net_tcp

--- a/testing/nettest/Makefile
+++ b/testing/nettest/Makefile
@@ -28,7 +28,7 @@ MODULE    = $(CONFIG_TESTING_NET_TEST)
 
 ifeq ($(CONFIG_TESTING_NET_TEST),y)
 
-CFLAGS += -I$(NETTEST_UTILS_DIR)
+CFLAGS   += -I$(NETTEST_UTILS_DIR)
 
 ifeq ($(CONFIG_TESTING_NET_TCP),y)
 MAINSRC  += tcp/test_tcp.c
@@ -41,6 +41,15 @@ endif
 
 ifeq ($(CONFIG_NET_IPv6), y)
 CSRCS    += tcp/test_tcp_connect_ipv6.c
+endif
+
+ifeq ($(CONFIG_NET_PKT), y)
+CSRCS    += tcp/test_tcp_connect_rst.c utils/nettest_netdump.c
+
+ifeq ($(CONFIG_NET_SOLINGER), y)
+CSRCS    += tcp/test_tcp_connect_solinger.c
+endif
+
 endif
 
 endif

--- a/testing/nettest/tcp/test_tcp.c
+++ b/testing/nettest/tcp/test_tcp.c
@@ -48,6 +48,16 @@ int main(int argc, FAR char *argv[])
                                       test_tcp_connect_ipv6_setup,
                                       test_tcp_common_teardown),
 #endif
+#ifdef CONFIG_NET_PKT
+#ifdef CONFIG_NET_SOLINGER
+      cmocka_unit_test_setup_teardown(test_tcp_connect_solinger,
+                                      test_tcp_connect_solinger_setup,
+                                      test_tcp_common_teardown),
+#endif
+      cmocka_unit_test_setup_teardown(test_tcp_connect_rst,
+                                      test_tcp_connect_rst_setup,
+                                      test_tcp_common_teardown),
+#endif /* CONFIG_NET_PKT */
     };
 
   return cmocka_run_group_tests(tcp_tests, test_tcp_group_setup,

--- a/testing/nettest/tcp/test_tcp.h
+++ b/testing/nettest/tcp/test_tcp.h
@@ -27,14 +27,19 @@
 
 #include <pthread.h>
 
+#include "utils.h"
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/
 
 struct nettest_tcp_state_s
 {
-  int       client_fd;
-  pthread_t server_tid;
+  int               client_fd;
+  pthread_t         server_tid;
+#ifdef CONFIG_NET_PKT
+  struct net_dump_s dump_state;
+#endif
 };
 
 /****************************************************************************
@@ -58,6 +63,13 @@ int test_tcp_group_teardown(FAR void **state);
  ****************************************************************************/
 
 int test_tcp_common_teardown(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_common_setup
+ ****************************************************************************/
+
+int test_tcp_common_setup(FAR struct nettest_tcp_state_s *tcp_state,
+                          int family, nettest_filter_t filter);
 
 /****************************************************************************
  * Name: test_tcp_connect_ipv4_setup
@@ -86,4 +98,32 @@ int test_tcp_connect_ipv6_setup(FAR void **state);
 
 void test_tcp_connect_ipv6(FAR void **state);
 #endif
+
+/****************************************************************************
+ * Name: test_tcp_connect_solinger_setup
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_PKT
+#ifdef CONFIG_NET_SOLINGER
+int test_tcp_connect_solinger_setup(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_connect_solinger
+ ****************************************************************************/
+
+void test_tcp_connect_solinger(FAR void **state);
+#endif
+
+/****************************************************************************
+ * Name: test_tcp_connect_rst_setup
+ ****************************************************************************/
+
+int test_tcp_connect_rst_setup(FAR void **state);
+
+/****************************************************************************
+ * Name: test_tcp_connect_rst
+ ****************************************************************************/
+
+void test_tcp_connect_rst(FAR void **state);
+#endif /* CONFIG_NET_PKT */
 #endif /* __APPS_TESTING_NETTEST_TCP_TEST_TCP_H */

--- a/testing/nettest/tcp/test_tcp_connect_ipv6.c
+++ b/testing/nettest/tcp/test_tcp_connect_ipv6.c
@@ -27,8 +27,8 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
+
 #include <cmocka.h>
-#include <sys/time.h>
 
 #include "test_tcp.h"
 #include "utils.h"
@@ -52,23 +52,8 @@
 int test_tcp_connect_ipv6_setup(FAR void **state)
 {
   FAR struct nettest_tcp_state_s *tcp_state = *state;
-  struct timeval tv;
-  int ret;
 
-  tcp_state->client_fd = socket(PF_INET6, SOCK_STREAM, 0);
-  assert_true(tcp_state->client_fd > 0);
-
-  tv.tv_sec  = 0;
-  tv.tv_usec = 10000;
-  ret = setsockopt(tcp_state->client_fd, SOL_SOCKET,
-                   SO_RCVTIMEO, &tv, sizeof(tv));
-  assert_return_code(ret, errno);
-
-  ret = setsockopt(tcp_state->client_fd, SOL_SOCKET,
-                   SO_SNDTIMEO, &tv, sizeof(tv));
-  assert_return_code(ret, errno);
-
-  return 0;
+  return test_tcp_common_setup(tcp_state, AF_INET6, NULL);
 }
 
 /****************************************************************************

--- a/testing/nettest/tcp/test_tcp_connect_solinger.c
+++ b/testing/nettest/tcp/test_tcp_connect_solinger.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * apps/testing/nettest/tcp/test_tcp_connect_ipv4.c
+ * apps/testing/nettest/tcp/test_tcp_connect_solinger.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -22,54 +22,58 @@
  * Included Files
  ****************************************************************************/
 
-#include <netinet/in.h>
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/socket.h>
-
 #include <cmocka.h>
+
+#include <nuttx/net/tcp.h>
 
 #include "test_tcp.h"
 #include "utils.h"
 
 /****************************************************************************
- * Pre-processor Definitions
+ * Private Functions
  ****************************************************************************/
 
-#define TEST_LOOP_CNT    5
-#define TEST_BUFFER_SIZE 80
-#define TEST_MSG         "loopback message"
+static bool filter(FAR uint8_t *buf)
+{
+  return nettest_filter_tcp_state(NET_LL_LOOPBACK, TCP_RST, buf);
+}
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: test_tcp_connect_ipv4_setup
+ * Name: test_tcp_connect_solinger_setup
  ****************************************************************************/
 
-int test_tcp_connect_ipv4_setup(FAR void **state)
+int test_tcp_connect_solinger_setup(FAR void **state)
 {
   FAR struct nettest_tcp_state_s *tcp_state = *state;
 
-  return test_tcp_common_setup(tcp_state, AF_INET, NULL);
+  return test_tcp_common_setup(tcp_state, AF_INET, filter);
 }
 
 /****************************************************************************
- * Name: test_tcp_connect_ipv4
+ * Name: test_tcp_connect_solinger
  ****************************************************************************/
 
-void test_tcp_connect_ipv4(FAR void **state)
+void test_tcp_connect_solinger(FAR void **state)
 {
   FAR struct nettest_tcp_state_s *tcp_state = *state;
   struct sockaddr_in myaddr;
-  char outbuf[TEST_BUFFER_SIZE];
-  char inbuf[TEST_BUFFER_SIZE];
+  struct linger so_linger;
   int addrlen;
   int ret;
-  int len;
+
+  so_linger.l_onoff = TRUE;
+  so_linger.l_linger = 0;
+  ret = setsockopt(tcp_state->client_fd, SOL_SOCKET,
+                   SO_LINGER, &so_linger, sizeof so_linger);
+  assert_return_code(ret, errno);
 
   addrlen = nettest_lo_addr((FAR struct sockaddr *)&myaddr, AF_INET);
 
@@ -77,17 +81,10 @@ void test_tcp_connect_ipv4(FAR void **state)
                 addrlen);
   assert_return_code(ret, errno);
 
-  for (int i = 0; i < TEST_LOOP_CNT; i++)
-    {
-      strcpy(outbuf, TEST_MSG);
-      len = strlen(outbuf);
-      ret = send(tcp_state->client_fd, outbuf, len, 0);
-      assert_true(ret == len);
+  close(tcp_state->client_fd);
+  tcp_state->client_fd = -1;
 
-      ret = recv(tcp_state->client_fd, inbuf, TEST_BUFFER_SIZE, 0);
-      assert_true(ret == len);
+  nettest_netdump_stop(&tcp_state->dump_state);
 
-      ret = strncmp(inbuf, TEST_MSG, len);
-      assert_true(ret == 0);
-    }
+  assert_int_equal(sq_count(&tcp_state->dump_state.data), 1);
 }

--- a/testing/nettest/utils/nettest_netdump.c
+++ b/testing/nettest/utils/nettest_netdump.c
@@ -1,0 +1,315 @@
+/****************************************************************************
+ * apps/testing/nettest/utils/nettest_netdump.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <net/if.h>
+#include <netpacket/packet.h>
+#include <stdio.h>
+
+#include <nuttx/net/net.h>
+#include <nuttx/net/tcp.h>
+
+#include "utils.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define TEST_DUMP_WIAT_TIME      10
+#define TEST_WAIT_TRANS_FIN_TIME 10000
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: socket_open
+ ****************************************************************************/
+
+static int socket_open(int ifindex)
+{
+  int sd;
+  struct sockaddr_ll addr;
+
+  sd = socket(PF_PACKET, SOCK_RAW | SOCK_NONBLOCK, 0);
+  if (sd < 0)
+    {
+      perror("ERROR: failed to create packet socket");
+      return -errno;
+    }
+
+  /* Prepare sockaddr struct */
+
+  addr.sll_family = AF_PACKET;
+  addr.sll_ifindex = ifindex;
+  if (bind(sd, (FAR const struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
+      perror("ERROR: binding socket failed");
+      close(sd);
+      return -errno;
+    }
+
+  return sd;
+}
+
+/****************************************************************************
+ * Name: nettest_netdump_stop_work
+ ****************************************************************************/
+
+static void nettest_netdump_stop_work(FAR void *arg)
+{
+  FAR struct net_dump_s *netdump_state = (FAR struct net_dump_s *)arg;
+  netdump_state->count = 0;
+}
+
+/****************************************************************************
+ * Name: nettest_tcpdump
+ ****************************************************************************/
+
+static FAR void *nettest_netdump(pthread_addr_t pvarg)
+{
+  int sd;
+  ssize_t len;
+  uint8_t buf[MAX_NETDEV_PKTSIZE];
+  FAR struct buf_node_s *buf_node;
+  FAR struct net_dump_s *netdump_state = (FAR struct net_dump_s *)pvarg;
+
+  sd = socket_open(netdump_state->ifindex);
+  if (sd < 0)
+    {
+      return NULL;
+    }
+
+  while (netdump_state->count > 0)
+    {
+      len = read(sd, buf, sizeof(buf));
+
+      if ((len == 0) || (len == -1 && errno == EAGAIN))
+        {
+          usleep(TICK_PER_MSEC);
+          continue;
+        }
+      else if (len < 0)
+        {
+          break;
+        }
+
+      work_queue(USRWORK, &netdump_state->work, nettest_netdump_stop_work,
+                 netdump_state, TEST_DUMP_WIAT_TIME * TICK_PER_MSEC);
+
+      if (netdump_state->filter(buf) == false)
+        {
+          continue;
+        }
+      else
+        {
+          netdump_state->count--;
+          buf_node = malloc(sizeof(struct buf_node_s));
+          if (buf_node == NULL)
+            {
+              perror("ERROR: failed to allocate memory");
+              break;
+            }
+
+          memcpy(buf_node->buf, buf, len);
+          buf_node->len = len;
+          sq_addlast(buf_node, &netdump_state->data);
+        }
+    }
+
+  work_cancel_sync(USRWORK, &netdump_state->work);
+  close(sd);
+
+  return NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nettest_l3len
+ ****************************************************************************/
+
+uint8_t nettest_l3len(enum net_lltype_e lltype, uint8_t len)
+{
+  assert(lltype == NET_LL_ETHERNET || lltype == NET_LL_LOOPBACK);
+  switch (lltype)
+    {
+      case NET_LL_ETHERNET:
+        return len - ETH_HDRLEN;
+
+      case NET_LL_LOOPBACK:
+      default:
+        return len;
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_l3buf
+ ****************************************************************************/
+
+FAR uint8_t *nettest_l3buf(enum net_lltype_e lltype, FAR uint8_t *l2buf)
+{
+  assert(lltype == NET_LL_ETHERNET || lltype == NET_LL_LOOPBACK);
+  switch (lltype)
+    {
+      case NET_LL_ETHERNET:
+        return l2buf + ETH_HDRLEN;
+
+      case NET_LL_LOOPBACK:
+      default:
+        return l2buf;
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_l3proto
+ ****************************************************************************/
+
+uint8_t nettest_l3proto(FAR uint8_t *l3buf)
+{
+  return l3buf[0] & IP_VERSION_MASK;
+}
+
+/****************************************************************************
+ * Name: nettest_l4buf
+ ****************************************************************************/
+
+FAR uint8_t *nettest_l4buf(FAR uint8_t *l3buf)
+{
+  assert(nettest_l3proto(l3buf) == IPv4_VERSION ||
+         nettest_l3proto(l3buf) == IPv6_VERSION);
+  switch (nettest_l3proto(l3buf))
+    {
+      case IPv4_VERSION:
+        return l3buf + IPv4_HDRLEN;
+
+      case IPv6_VERSION:
+        return l3buf + IPv6_HDRLEN;
+
+      default:
+        return NULL;
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_l4proto
+ ****************************************************************************/
+
+uint8_t nettest_l4proto(FAR uint8_t *l3buf)
+{
+  assert(nettest_l3proto(l3buf) == IPv4_VERSION ||
+         nettest_l3proto(l3buf) == IPv6_VERSION);
+  switch (nettest_l3proto(l3buf))
+    {
+      case IPv4_VERSION:
+        FAR struct ipv4_hdr_s *ipv4 = (FAR struct ipv4_hdr_s *)l3buf;
+        return ipv4->proto;
+
+      case IPv6_VERSION:
+        FAR struct ipv6_hdr_s *ipv6 = (FAR struct ipv6_hdr_s *)l3buf;
+        return ipv6->proto;
+
+      default:
+        return 0;
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_filter_tcp_state
+ ****************************************************************************/
+
+bool nettest_filter_tcp_state(enum net_lltype_e lltype, uint16_t tcp_state,
+                              FAR uint8_t *buf)
+{
+  FAR uint8_t *l3buf = nettest_l3buf(lltype, buf);
+  FAR uint8_t *l4buf = nettest_l4buf(l3buf);
+
+  if (nettest_l4proto(l3buf) == IP_PROTO_TCP)
+    {
+      FAR struct tcp_hdr_s *th = (FAR struct tcp_hdr_s *)l4buf;
+      return (th->flags & tcp_state) != 0;
+    }
+
+  return false;
+}
+
+/****************************************************************************
+ * Name: nettest_netdump_stop
+ ****************************************************************************/
+
+void nettest_netdump_stop(FAR struct net_dump_s *netdump_state)
+{
+  if (netdump_state->tid > 0)
+    {
+      /* Delay ensures all packets are caught */
+
+      usleep(TEST_WAIT_TRANS_FIN_TIME);
+      nettest_netdump_stop_work(netdump_state);
+      pthread_join(netdump_state->tid, NULL);
+      netdump_state->tid = -1;
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_dump_destroy
+ ****************************************************************************/
+
+void nettest_dump_destroy(FAR struct net_dump_s *netdump_state)
+{
+  FAR struct buf_node_s *node;
+  FAR struct buf_node_s *tmp;
+
+  nettest_netdump_stop(netdump_state);
+
+  sq_for_every_safe(&netdump_state->data, node, tmp)
+    {
+      sq_rem(node, &netdump_state->data);
+      free(node);
+    }
+}
+
+/****************************************************************************
+ * Name: nettest_dump_setup
+ ****************************************************************************/
+
+int nettest_dump_setup(FAR struct net_dump_s *cfg,
+                       FAR const char *netdev_name,
+                       nettest_filter_t filter, uint16_t count)
+{
+  cfg->filter = filter;
+  sq_init(&cfg->data);
+  memset(&cfg->work, 0, sizeof(struct work_s));
+
+  cfg->ifindex = if_nametoindex(netdev_name);
+  if (cfg->ifindex == 0)
+    {
+      printf("Failed to get index of device %s\n", netdev_name);
+      return NULL;
+    }
+
+  cfg->count = (count == 0) ? INT32_MAX : count;
+
+  return pthread_create(&cfg->tid, NULL, nettest_netdump, cfg);
+}

--- a/testing/nettest/utils/utils.h
+++ b/testing/nettest/utils/utils.h
@@ -26,7 +26,36 @@
  ****************************************************************************/
 
 #include <pthread.h>
-#include <sys/socket.h>
+
+#include <nuttx/net/net.h>
+#include <nuttx/net/netconfig.h>
+
+typedef CODE bool (*nettest_filter_t)(FAR uint8_t *);
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_PKT
+struct buf_node_s
+{
+  FAR struct buf_node_s *flink;
+  uint8_t len;
+  uint8_t buf[MAX_NETDEV_PKTSIZE];
+};
+
+struct net_dump_s
+{
+  struct work_s work;
+  pthread_t tid;
+
+  sq_queue_t data;
+
+  nettest_filter_t filter;
+  int ifindex;
+  int count;
+};
+#endif
 
 /****************************************************************************
  * Public Function Prototypes
@@ -50,5 +79,64 @@ int nettest_destroy_tcp_lo_server(pthread_t server_tid);
  ****************************************************************************/
 
 pthread_t nettest_create_tcp_lo_server(void);
+#endif
+
+/****************************************************************************
+ * Name: nettest_l3len
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_PKT
+uint8_t nettest_l3len(enum net_lltype_e lltype, uint8_t len);
+
+/****************************************************************************
+ * Name: nettest_l3buf
+ ****************************************************************************/
+
+FAR uint8_t *nettest_l3buf(enum net_lltype_e lltype, FAR uint8_t *l2buf);
+
+/****************************************************************************
+ * Name: nettest_l3proto
+ ****************************************************************************/
+
+uint8_t nettest_l3proto(FAR uint8_t *l3buf);
+
+/****************************************************************************
+ * Name: nettest_l4buf
+ ****************************************************************************/
+
+FAR uint8_t *nettest_l4buf(FAR uint8_t *l3buf);
+
+/****************************************************************************
+ * Name: nettest_l4proto
+ ****************************************************************************/
+
+uint8_t nettest_l4proto(FAR uint8_t *l3buf);
+
+/****************************************************************************
+ * Name: nettest_filter_tcp_state
+ ****************************************************************************/
+
+bool nettest_filter_tcp_state(enum net_lltype_e lltype, uint16_t tcp_state,
+                              FAR uint8_t *buf);
+
+/****************************************************************************
+ * Name: nettest_netdump_stop
+ ****************************************************************************/
+
+void nettest_netdump_stop(FAR struct net_dump_s *netdump_state);
+
+/****************************************************************************
+ * Name: nettest_dump_destroy
+ ****************************************************************************/
+
+void nettest_dump_destroy(FAR struct net_dump_s *tcpdump_state);
+
+/****************************************************************************
+ * Name: nettest_dump_setup
+ ****************************************************************************/
+
+int nettest_dump_setup(FAR struct net_dump_s *cfg,
+                       FAR const char *netdev_name,
+                       nettest_filter_t filter, uint16_t count);
 #endif
 #endif /* __APPS_TESTING_NETTEST_UTILS_UTILS_H */


### PR DESCRIPTION
## Summary

Add a solinger testcase and a tcpserver error port processing testcase. In addition, a set of public packet capture functions for testing were added.

## Impact

N/A

## Testing

qemu environment test

