### PR TITLE
nshlib/nsh_parse: Fix variable arguments concat error of `nsh_execute()`

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -603,24 +603,25 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
     {
       FAR char *sh_argv[4];
       FAR char *sh_cmd = "sh";
-      int i;
+      char sh_arg2[CONFIG_NSH_LINELEN];
 
       DEBUGASSERT(strncmp(argv[0], sh_cmd, 3) != 0);
 
-      sh_argv[0] = sh_cmd;
-      sh_argv[1] = "-c";
-      for (i = 0; i < argc - 1; i++)
+      sh_arg2[0] = '\0';
+
+      for (ret = 0; ret < argc; ret++)
         {
-          FAR char *p_arg = argv[i];
-          size_t len = strlen(p_arg);
+          strlcat(sh_arg2, argv[ret], sizeof(sh_arg2));
 
-          /* Restore from split args to concat args. */
-
-          DEBUGASSERT(&p_arg[len + 1] == argv[i + 1]);
-          p_arg[len] = ' ';
+          if (ret < argc - 1)
+            {
+              strcat(sh_arg2, " ");
+            }
         }
 
-      sh_argv[2] = argv[0];
+      sh_argv[0] = sh_cmd;
+      sh_argv[1] = "-c";
+      sh_argv[2] = sh_arg2;
       sh_argv[3] = NULL;
 
       /* np.np_bg still there, try use nsh_builtin or nsh_fileapp to


### PR DESCRIPTION
## Summary
Pick from https://github.com/apache/nuttx-apps/pull/2850
Fix variable arguments concat error of `nsh_execute()`  
#### Without this patch
```
nsh> set time 5
nsh> echo $time
5
nsh> sleep $time &
sh [5:100]
nsh> nsh: sleep: missing required argument(s)
```
#### With this patch
```
  nsh> set time 5
  nsh> echo $time
  5
  nsh> sleep $time &
  sh [4:100]
  nsh> ps
    PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
      0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069616 Idle_Task
      1     0 224 FIFO     Kthread   - Waiting  Signal    0000000000000000 0067536 loop_task
      2     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067504 hpwork 0x501760e0 0x50176128
      3     3 100 FIFO     Task      - Running            0000000000000000 0067536 nsh_main
      4     4 100 FIFO     Task      - Waiting  Signal    0000000000000000 0067520 sh -c sleep
```
**Reported by yangao1@xiaomi.com, owned by @jasonbu,** updated by @JianyuWang0623
## Impact
nshlib/nsh_parse:nsh_execute()

## Testing
1. Selftest as above/commit message
2. NuttX CI
