### PR TITLE
tools:Remove the --param compilation option

### DIFF
--- a/tools/WASI-SDK.defs
+++ b/tools/WASI-SDK.defs
@@ -66,8 +66,9 @@ endif
 # -fsanitize%: -fsanitize=address, -fsanitize=thread etc.
 # -fno-sanitize%: -fno-sanitize=address, -fno-sanitize=thread etc.
 # -W%: Warning flags, clang is more strict than gcc
+# --param%: Warning flags, wasm-clang does not support
 
-CFLAGS_STRIP = -m% -Wl,% -fsanitize% -fno-sanitize% -W%
+CFLAGS_STRIP = -m% -Wl,% -fsanitize% -fno-sanitize% -W% --param%
 
 WCFLAGS += $(filter-out $(CFLAGS_STRIP),$(CFLAGS))
 WCFLAGS += --sysroot=$(WSYSROOT) -nostdlib -D__NuttX__


### PR DESCRIPTION
## Summary

*Fix warning flags, wasm-clang does not support
Related:https://github.com/open-vela/frameworks_runtimes_wasm/pull/3*

## Impact

*nop*

## Testing

*cd vela
./build.sh vendor/xring/boards/marconi/o62m/configs/ap
./build.sh menuconfig and enable following configs: INTERPRETERS_WAMR, INTERPRETERS_WAMR_AOT, INTERPRETERS_WAMR_CONFIGUABLE_BOUNDS_CHECKS, INTERPRETERS_WAMR_CUSTOM_NAME_SECTIONS, INTERPRETERS_WAMR_DUMP_CALL_STACK，INTERPRETERS_WAMR_LIBC_BUILTIN，INTERPRETERS_WAMR_LIB_PTHREAD，INTERPRETERS_WAMR_LOG，INTERPRETERS_WAMR_REF_TYPES，INTERPRETERS_WAMR_SHARED_MEMORY，INTERPRETERS_WAMR_STACKSIZE=32768，INTERPRETERS_WAMR_THREAD_MGR
flashing wearable devices
(1)Flash vela_ap.bin to the wearable devices
(2)Successfully dialed and answered the phone.
(3)Logged into the third-party app and can browse the internet normally.*

