### PR TITLE
If file name too long,can show next dir and no error info

### DIFF
--- a/nshlib/nsh_fscmds.c
+++ b/nshlib/nsh_fscmds.c
@@ -633,7 +633,7 @@ static int ls_recursive(FAR struct nsh_vtbl_s *vtbl, FAR const char *dirpath,
       free(newpath);
     }
 
-  return ret;
+  return OK;
 }
 
 #endif /* !CONFIG_NSH_DISABLE_LS */

--- a/nshlib/nsh_fsutils.c
+++ b/nshlib/nsh_fsutils.c
@@ -453,7 +453,6 @@ int nsh_foreach_direntry(FAR struct nsh_vtbl_s *vtbl, FAR const char *cmd,
         }
 
 #endif
-      nsh_error(vtbl, g_fmtcmdfailed, cmd, "opendir", NSH_ERRNO);
       return ERROR;
     }
 


### PR DESCRIPTION
## Summary

If file name too long,can show next dir and no error info

## Impact

no impact

## Testing

local test passed

