### PR TITLE
apps/nshlib: Remove the deprecated config `NSH_LINELEN`

### DIFF
--- a/nshlib/Kconfig
+++ b/nshlib/Kconfig
@@ -125,14 +125,6 @@ config NSH_CLE
 
 endchoice
 
-config NSH_LINELEN
-	int "Max command line length"
-	default 64 if DEFAULT_SMALL
-	default 80 if !DEFAULT_SMALL
-	---help---
-		The maximum length of one command line and of one output line.
-		Default: 64/80
-
 config NSH_DISABLE_SEMICOLON
 	bool "Disable multiple commands per line"
 	default DEFAULT_SMALL


### PR DESCRIPTION
> Pick from
> https://github.com/apache/nuttx-apps/pull/2945

## Summary
* apps/nshlib: Remove the deprecated config `NSH_LINELEN`.
* POSIX standard `LINE_MAX` is used instead.
* See https://github.com/apache/nuttx/pull/15541 and https://github.com/apache/nuttx-apps/pull/2943 please.

## Impact
apps/nshlib

## Testing
CI
