### PR TITLE
system/coredump: fix core file size mismatch

### DIFF
--- a/system/coredump/coredump.c
+++ b/system/coredump/coredump.c
@@ -240,7 +240,13 @@ static void coredump_restore(FAR char *savepath, size_t maxfile)
   lseek(blkfd, 0, SEEK_SET);
   while (offset < info.size)
     {
-      readsize = read(blkfd, swap, CONFIG_SYSTEM_COREDUMP_SWAPBUFFER_SIZE);
+      readsize = info.size - offset;
+      if (readsize > CONFIG_SYSTEM_COREDUMP_SWAPBUFFER_SIZE)
+        {
+          readsize = CONFIG_SYSTEM_COREDUMP_SWAPBUFFER_SIZE;
+        }
+
+      readsize = read(blkfd, swap, readsize);
       if (readsize < 0)
         {
           printf("Read %s fail\n", CONFIG_SYSTEM_COREDUMP_DEVPATH);


### PR DESCRIPTION

## Summary

system/coredump: fix core file size mismatch

## Impact

no impact

## Testing

ci test

