### PR TITLE
wasm toolchain: add --enable-gc to wamrc if GC enabled

### DIFF
--- a/interpreters/wamr/Toolchain.defs
+++ b/interpreters/wamr/Toolchain.defs
@@ -65,6 +65,10 @@ else
   WABITYPE = $(LLVM_ABITYPE)
 endif
 
+ifeq ($(CONFIG_INTERPRETERS_WAMR_GC),y)
+  RCFLAGS += --enable-gc
+endif
+
 RCFLAGS += --target=$(WTARGET) --target-abi=$(WABITYPE) --cpu=$(WCPU)
 
 define WAMR_AOT_COMPILE


### PR DESCRIPTION
## Summary

If the config CONFIG_INTERPRETERS_WAMR_GC for building wamr is enabled, the --enable-gc should be also enabled for compiling wasm

## Impact

Enable Garbage Collection support to wasm

## Testing

Compiling wasm with --enable-gc, and run this wasm with iwasm
