### PR TITLE
Build the quickjs unit test framework by generating a ROMFS image

### DIFF
--- a/interpreters/quickjs/CMakeLists.txt
+++ b/interpreters/quickjs/CMakeLists.txt
@@ -135,6 +135,18 @@ if(CONFIG_INTERPRETERS_QUICKJS)
     list(APPEND QUICKJS_CSRCS ${QUICKJS_DIR}/quickjs-libc.c)
   endif()
 
+  if(CONFIG_INTERPRETERS_QUICKJS_TEST)
+    add_custom_target(
+      qjstest_img
+      COMMAND genromfs -f ${CMAKE_BINARY_DIR}/etc/qjstest.img -d
+              ${QUICKJS_DIR}/tests -V "ROMFS_Test"
+      WORKING_DIRECTORY ${QUICKJS_DIR}
+      COMMENT "QUICKJS UNIT TEST Generating qjstest.img...")
+
+    add_dynamic_rcraws(RAWS ${CMAKE_BINARY_DIR}/etc/qjstest.img DEPENDS
+                       qjstest_img)
+  endif()
+
   nuttx_add_library(libqjs)
   target_sources(libqjs PRIVATE ${QUICKJS_CSRCS})
   target_include_directories(libqjs PRIVATE ${QUICKJS_INCDIR})

--- a/interpreters/quickjs/Kconfig
+++ b/interpreters/quickjs/Kconfig
@@ -72,4 +72,8 @@ config INTERPRETERS_QUICKJS_CPUPROFILING
 	bool "Enable QUICKJS_CPUPROFILING"
 	default n
 
+config INTERPRETERS_QUICKJS_TEST
+	bool "Enable QuickJS test"
+	default n
+
 endif # INTERPRETERS_QUICKJS


### PR DESCRIPTION
## Summary

Complete the unit test of quickjs through the existing js test file

## Impact

Only affects cmake compilation and generates an image

