### PR TITLE
Solve static checking problems.

### DIFF
--- a/system/critmon/critmon.c
+++ b/system/critmon/critmon.c
@@ -222,8 +222,8 @@ static int critmon_process_directory(FAR struct dirent *entryp)
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
   maxpreemp = pos;
-  pos = strchr(pos, ',');
-  if (pos != NULL)
+  pos = strchrnul(pos, ',');
+  if (*pos != '\0')
     {
       *pos++ = '\0';
     }
@@ -233,8 +233,8 @@ static int critmon_process_directory(FAR struct dirent *entryp)
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
   maxcrit = pos;
-  pos = strchr(pos, ',');
-  if (pos != NULL)
+  pos = strchrnul(pos, ',');
+  if (*pos != '\0')
     {
       *pos++ = '\0';
     }
@@ -244,15 +244,15 @@ static int critmon_process_directory(FAR struct dirent *entryp)
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   maxrun = pos;
-  pos = strchr(pos, ',');
-  if (pos != NULL)
+  pos = strchrnul(pos, ',');
+  if (*pos != '\0')
     {
       *pos++ = '\0';
     }
 
   runtime = pos;
-  pos = strchr(pos, ',');
-  if (pos != NULL)
+  pos = strchrnul(pos, ',');
+  if (*pos != '\0')
     {
       *pos++ = '\0';
     }
@@ -362,16 +362,16 @@ static void critmon_global_crit(void)
 
       pos = critmon_isolate_value(g_critmon.line);
       cpu = pos;
-      pos = strchr(pos, ',');
-      if (pos != NULL)
+      pos = strchrnul(pos, ',');
+      if (*pos != '\0')
         {
           *pos++ = '\0';
         }
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
       maxpreemp = pos;
-      pos = strchr(pos, ',');
-      if (pos != NULL)
+      pos = strchrnul(pos, ',');
+      if (*pos != '\0')
         {
           *pos++ = '\0';
         }
@@ -381,8 +381,8 @@ static void critmon_global_crit(void)
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION >= 0
       maxcrit = pos;
-      pos = strchr(pos, ',');
-      if (pos != NULL)
+      pos = strchrnul(pos, ',');
+      if (*pos != '\0')
         {
           *pos++ = '\0';
         }


### PR DESCRIPTION
## Summary

### problem
The code detection tool thinks that when if (pos != NULL) is false, that is, when pos is null, the strchr(pos, ',') operation will be performed on pos, causing a null pointer error, for example:

line 226: if (*pos != '\0')     when pos is null.
line 236: pos = strchrnul(pos, ',');    Dereference of a null pointer.

However,  this will not happen, because the configuration condition(line 234) will be judged first. If pos is null, line 236 will not be executed.

### SOLUTION
Use strchrnul to replace strchr. Even if no characters are matched, a null pointer will not be returned, thus avoiding incorrect judgment by code detection tools.

## Impact

None.

## Testing

No problem.

