### PR TITLE
apps:Add depends to different test cases

### DIFF
--- a/examples/unionfs/Kconfig
+++ b/examples/unionfs/Kconfig
@@ -6,7 +6,7 @@
 config EXAMPLES_UNIONFS
 	tristate "Union file system example"
 	default n
-	depends on (FS_ROMFS || FS_UNIONFS) && BUILD_FLAT
+	depends on FS_ROMFS && FS_UNIONFS && BUILD_FLAT
 	---help---
 		Enable the Union File System example
 

--- a/examples/userfs/Kconfig
+++ b/examples/userfs/Kconfig
@@ -5,6 +5,7 @@
 
 config EXAMPLES_USERFS
 	tristate "UserFS test"
+	depends on FS_USERFS
 	default n
 	---help---
 		Enables a simple test of the UserFS

--- a/testing/nxffs/Kconfig
+++ b/testing/nxffs/Kconfig
@@ -5,6 +5,7 @@
 
 config TESTING_NXFFS
 	tristate "NXFFS file system example"
+	depends on FS_NXFFS && RAMMTD
 	default n
 	---help---
 		Enable the NXFFS file system example

--- a/testing/smart/Kconfig
+++ b/testing/smart/Kconfig
@@ -5,6 +5,7 @@
 
 config TESTING_SMART
 	tristate "SMART file system example"
+	depends on SMART_DEV_LOOP && RAMMTD && FS_SMARTFS
 	default n
 	---help---
 		Enable the SMART file system example


### PR DESCRIPTION
## Summary
  Added dependencies to some example demos to avoid case run failed
  Add items:
  1. ftpd
  2. unionfs
  3. userfs
  4. nxffs
  5. smart

## Impact
  Add compilation dependencies

## Testing
  There is no effect on the original test case itself
