### PR TITLE
examples/romfs:add EXAMPLES_ROMFS_RAMDEVNO

### DIFF
--- a/examples/romfs/Kconfig
+++ b/examples/romfs/Kconfig
@@ -11,4 +11,11 @@ config EXAMPLES_ROMFS
 		Enable the ROMFS example
 
 if EXAMPLES_ROMFS
+
+config EXAMPLES_ROMFS_RAMDEVNO
+	int "ROMFS example ramdevno"
+	default 10
+	---help---
+		Custom RAMDisk number
+
 endif


### PR DESCRIPTION
## Summary
  Add EXAMPLES_ROMFS_RAMDEVNO for custom initliaze ramdisk number,  avoid failure of the final use case because registering ramdisk in the runtime environment and duplicate other applications

## Impact
  None, add marco for custom register RAMDEVNO

## Testing
  Testing in Sim / Qemu, it can work fine.
