### PR TITLE
ostest:Fix the issue that nxevent pthread was not executed, causing case failed

### DIFF
--- a/testing/ostest/nxevent.c
+++ b/testing/ostest/nxevent.c
@@ -278,7 +278,7 @@ void nxevent_test(void)
 
   /* Lower priority */
 
-  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY - 1;
+  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY;
   pthread_attr_setschedparam(&attr, &sparam);
 
   /* Create thread */
@@ -301,7 +301,7 @@ void nxevent_test(void)
 
   /* Lower priority */
 
-  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY - 1;
+  sparam.sched_priority = PTHREAD_DEFAULT_PRIORITY;
   pthread_attr_setschedparam(&attr, &sparam);
 
   /* Create thread */


### PR DESCRIPTION
## Summary
  In the case of complex business and slow overall system response (such as when MM_KASAN is turned on), the nxevent case work thread will not be executed and will be switched back to the main thread, so that the event does not get the expected result and the case fails.
By adjusting the thread priority, the work thread can be scheduled to avoid the expected result failure

## Impact
  None, just adjust case pthread priority.

## Testing
  Testing in Qemu, it can work fine.
  

