### PR TITLE
kernel/syscall: fix required INET may case no support

### DIFF
--- a/testing/testsuites/kernel/syscall/cmocka_syscall_test.c
+++ b/testing/testsuites/kernel/syscall/cmocka_syscall_test.c
@@ -159,6 +159,7 @@ int main(int argc, char *argv[])
           test_nuttx_syscall_getpeername01,
           test_nuttx_syscall_test_group_setup,
           test_nuttx_syscall_test_group_teardown),
+#  ifdef CONFIG_NET_IPv4
       cmocka_unit_test_setup_teardown(
           test_nuttx_syscall_getsockopt01,
           test_nuttx_syscall_test_group_setup,
@@ -173,6 +174,7 @@ int main(int argc, char *argv[])
           test_nuttx_syscall_setsockopt01,
           test_nuttx_syscall_test_group_setup,
           test_nuttx_syscall_test_group_teardown),
+#  endif
       cmocka_unit_test_setup_teardown(
           test_nuttx_syscall_listen01,
           test_nuttx_syscall_test_group_setup,


### PR DESCRIPTION
## Summary
The test case using INet Socket, and the platform maybe not supported.

## Impact
The board those no support for INet now skip the case will not support.

## Testing
CI-test.

