### PR TITLE
system/fastboot: Add support for fastboot oem shell

### DIFF
--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -24,8 +24,9 @@ config SYSTEM_FASTBOOTD_DOWNLOAD_MAX
 	int "USB-fastboot download buffer size"
 	default 40960
 
-config FASTBOOTD_USB_BOARDCTL
+config SYSTEM_FASTBOOTD_USB_BOARDCTL
 	bool "USB Board Control"
+	default n
 	depends on BOARDCTL
 	depends on BOARDCTL_USBDEVCTRL
 	---help---

--- a/system/fastboot/Kconfig
+++ b/system/fastboot/Kconfig
@@ -31,4 +31,14 @@ config FASTBOOTD_USB_BOARDCTL
 	---help---
 		Connect usbdev before running fastboot daemon.
 
+config SYSTEM_FASTBOOTD_SHELL
+	bool "Execute custom commands"
+	default n
+	depends on SCHED_CHILD_STATUS
+	depends on SYSTEM_POPEN
+	---help---
+		Enable to support executing custom commands.
+		e.g. fastboot oem shell ps
+		e.g. fastboot oem shell "mkrd -m 10 -s 512 640"
+
 endif # SYSTEM_FASTBOOTD

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -1001,7 +1001,7 @@ int main(int argc, FAR char **argv)
   FAR void *buffer = NULL;
   int ret = OK;
 
-#ifdef CONFIG_FASTBOOTD_USB_BOARDCTL
+#ifdef CONFIG_SYSTEM_FASTBOOTD_USB_BOARDCTL
   struct boardioc_usbdev_ctrl_s ctrl;
 #  ifdef CONFIG_USBDEV_COMPOSITE
     uint8_t dev = BOARDIOC_USBDEV_COMPOSITE;
@@ -1035,7 +1035,7 @@ int main(int argc, FAR char **argv)
       fb_err("boardctl(BOARDIOC_USBDEV_CONTROL) failed: %d\n", ret);
       return ret;
     }
-#endif /* FASTBOOTD_USB_BOARDCTL */
+#endif /* SYSTEM_FASTBOOTD_USB_BOARDCTL */
 
   if (argc > 1)
     {

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -258,9 +258,15 @@ static void fastboot_ack(FAR struct fastboot_ctx_s *context,
 }
 
 static void fastboot_fail(FAR struct fastboot_ctx_s *context,
-                          FAR const char *reason)
+                          FAR const char *fmt, ...)
 {
+  char reason[FASTBOOT_MSG_LEN];
+  va_list ap;
+
+  va_start(ap, fmt);
+  vsnprintf(reason, sizeof(reason), fmt, ap);
   fastboot_ack(context, "FAIL", reason);
+  va_end(ap);
 }
 
 static void fastboot_okay(FAR struct fastboot_ctx_s *context,

--- a/system/fastboot/fastboot.c
+++ b/system/fastboot/fastboot.c
@@ -44,6 +44,7 @@
 #include <sys/statfs.h>
 #include <sys/types.h>
 #include <sys/poll.h>
+#include <sys/wait.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -178,6 +179,10 @@ static void fastboot_memdump(FAR struct fastboot_ctx_s *context,
                              FAR const char *arg);
 static void fastboot_filedump(FAR struct fastboot_ctx_s *context,
                               FAR const char *arg);
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SHELL
+static void fastboot_shell(FAR struct fastboot_ctx_s *context,
+                           FAR const char *arg);
+#endif
 
 /****************************************************************************
  * Private Data
@@ -198,7 +203,10 @@ static const struct fastboot_cmd_s g_fast_cmd[] =
 static const struct fastboot_cmd_s g_oem_cmd[] =
 {
   { "filedump",           fastboot_filedump         },
-  { "memdump",            fastboot_memdump          }
+  { "memdump",            fastboot_memdump          },
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SHELL
+  { "shell",              fastboot_shell            },
+#endif
 };
 
 /****************************************************************************
@@ -773,6 +781,37 @@ static void fastboot_filedump(FAR struct fastboot_ctx_s *context,
   context->upload_func = fastboot_filedump_upload;
   fastboot_okay(context, "");
 }
+
+#ifdef CONFIG_SYSTEM_FASTBOOTD_SHELL
+static void fastboot_shell(FAR struct fastboot_ctx_s *context,
+                           FAR const char *arg)
+{
+  char response[FASTBOOT_MSG_LEN - 4];
+  FILE *fp;
+  int ret;
+
+  fp = popen(arg, "r");
+  if (fp == NULL)
+    {
+      fastboot_fail(context, "popen() fails %d", errno);
+      return;
+    }
+
+  while (fgets(response, sizeof(response), fp))
+    {
+      fastboot_ack(context, "TEXT", response);
+    }
+
+  ret = pclose(fp);
+  if (WIFEXITED(ret) && WEXITSTATUS(ret) == 0)
+    {
+      fastboot_okay(context, "");
+      return;
+    }
+
+  fastboot_fail(context, "error detected 0x%x %d", ret, errno);
+}
+#endif
 
 static void fastboot_upload(FAR struct fastboot_ctx_s *context,
                             FAR const char *arg)


### PR DESCRIPTION
> **Pick from https://github.com/apache/nuttx-apps/pull/3003**
## Summary
Add support for fastboot oem shell to support executing custom commands.

Usage
```
fastboot oem shell <command>
```
## Impact
system/fastboot
## Testing
```
# Configuration "esp32s3-devkit:fastboot" with `SYSTEM_FASTBOOTD_SHELL` enabled

$ fastboot --version
fastboot version 35.0.2-12147458

$ fastboot oem shell ls /FILE_NOT_EXISTS
FAILED (remote: 'error detected 255 4')
fastboot: error: Command failed

$ fastboot oem shell ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003056 Idle_Task
    1     0 224 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001976 hpwork 0x3fc8bd50 0x3fc8bd80
    2     2 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004048 nsh_main
    3     3 100 RR       Task      - Ready              0000000000000000 0001992 fastbootd
    4     4 100 RR       Task      - Running            0000000000000000 0001992 popen -c ps
OKAY [  0.010s]
Finished. Total time: 0.010s
```
