### PR TITLE
nshlib/md5: Support reading from standard input

### DIFF
--- a/nshlib/nsh_codeccmd.c
+++ b/nshlib/nsh_codeccmd.c
@@ -507,6 +507,26 @@ int cmd_md5(FAR struct nsh_vtbl_s *vtbl, int argc, FAR char **argv)
           return ret;
         }
     }
+  else if (argc == 1)
+    {
+      MD5_CTX ctx;
+
+      md5_init(&ctx);
+
+      while (1)
+        {
+          ret = nsh_read(vtbl, digest, sizeof(digest));
+          if (ret <= 0)
+            {
+              ret = ret < 0 ? -errno : 0;
+              break;
+            }
+
+          md5_update(&ctx, digest, ret);
+        }
+
+      md5_final(digest, &ctx);
+    }
   else
     {
       md5_sum((FAR unsigned char *)argv[1], strlen(argv[1]), digest);

--- a/nshlib/nsh_command.c
+++ b/nshlib/nsh_command.c
@@ -359,7 +359,8 @@ static const struct cmdmap_s g_cmdmap[] =
 
 #if defined(CONFIG_NETUTILS_CODECS) && defined(CONFIG_CODECS_HASH_MD5)
 #  ifndef CONFIG_NSH_DISABLE_MD5
-  CMD_MAP("md5",      cmd_md5,      2, 3, "[-f] <string or filepath>"),
+  CMD_MAP("md5",      cmd_md5,      1, 3,
+          "[string] or [-f <filepath>] or read stdin"),
 #  endif
 #endif
 


### PR DESCRIPTION
# [please review again] Pick from apache/nuttx-apps, **NOT** merged to gerrit !!!
- (**!!! please review again !!!**) https://github.com/apache/nuttx-apps/pull/3115 (**!!! please review again !!!**)
## Summary
Sometimes users may want to calculate the MD5 of part of a file(e.g. check
partition contents for debug after flashing, size of which may be greater
than image). This can be done with the "dd" command and pipes, the "md5"
command just needs to support reading from standard input. For example:
`dd if=/dev/virtblk0 bs=512 count=1 | md5`.

## Impact
- nshlib/md5

## Testing
1. Selftest: PASS
```diff
11d10
< # CONFIG_SYSTEM_DD_STATS is not set
27d25
< CONFIG_CODECS_HASH_MD5=y
59d56
< CONFIG_NETUTILS_CODECS=y
```
```bash
# Test1
nsh> md5 -f /etc/init.d/rcS
1f0f871eca6a67fc58f2f33f03ea917fnsh> 
nsh> 
nsh> dd if=/etc/init.d/rcS | md5
sh [10:100]
1f0f871eca6a67fc58f2f33f03ea917fnsh> 
nsh>

# Test 2
nsh> cat /etc/init.d/rcS
fastbootd &
nsh> dd if=/etc/init.d/rcS bs=1 count=8 | md5
sh [12:100]
d7c865c834612f458707597e3be8a0f0nsh> 
nsh> echo -n "fastboot" | md5
sh [14:100]
d7c865c834612f458707597e3be8a0f0nsh> 
nsh>

git@github:/workspace $ dd if=./boards/xtensa/esp32s3/common/etctmp/etc/init.d/rcS bs=1 count=8 | md5sum
8+0 records in
8+0 records out
d7c865c834612f458707597e3be8a0f0  -
8 bytes copied, 2.032e-05 s, 394 kB/s
```
2. CI