### PR TITLE
system/iptables: avoid trap when run "iptables -L" if configured CONF…

### DIFF
--- a/system/iptables/iptables.c
+++ b/system/iptables/iptables.c
@@ -504,7 +504,7 @@ int main(int argc, FAR char *argv[])
   else
 #endif
 #ifdef CONFIG_NET_NAT
-  if (strcmp(args.table, TABLE_NAME_NAT) == 0)
+  if (args.table == NULL || strcmp(args.table, TABLE_NAME_NAT) == 0)
     {
       ret = iptables_apply(&args, iptables_nat_command);
       if (ret < 0)


### PR DESCRIPTION
system/iptables: avoid trap when run "iptables -L" if configured CONFIG_NET_NAT while not configured CONFIG_NET_IPFILTER
