### PR TITLE
nsh: fix nsh redirect fd double close

### DIFF
--- a/nshlib/nsh_parse.c
+++ b/nshlib/nsh_parse.c
@@ -731,6 +731,8 @@ static int nsh_execute(FAR struct nsh_vtbl_s *vtbl,
       if (vtbl->np.np_redir_out || vtbl->np.np_redir_in)
         {
           nsh_undirect(vtbl, save);
+          fd_out = -1;
+          fd_in = -1;
         }
     }
 


### PR DESCRIPTION
avoid double-close of redirection fds

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

