### PR TITLE
ci: check.yml: checkout open-vela repos instead of apache/nuttx

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,14 +30,13 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
+          repository: open-vela/nuttx
           path: nuttx
           fetch-depth: 0
 
       - name: Checkout apps repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx-apps
           path: apps
           fetch-depth: 0
 


### PR DESCRIPTION
The Check workflow was inherited from apache/nuttx-apps with hardcoded repository references to apache/nuttx and apache/nuttx-apps. The original intent was to align with upstream check rules, but since open-vela has diverged and not kept in sync, the base.sha in every PR refers to a commit that does not exist in apache repos, causing 'fatal: Invalid revision range' (exit 128).

Fix by pointing nuttx checkout to open-vela/nuttx and removing the hardcoded repository for apps (defaults to current repo).

## Summary

## Impact

## Testing

