### PR TITLE
ci: check.yml: checkout open-vela repos instead of apache/nuttx.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,14 +30,13 @@ jobs:
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
+          repository: open-vela/nuttx
           path: nuttx
           fetch-depth: 0
 
       - name: Checkout apps repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx-apps
           path: apps
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Mirror of [open-vela/nuttx-apps#106](https://github.com/open-vela/nuttx-apps/pull/106) (which targets the `dev` branch) for the `dev-ai-contest-2026` branch.

The `Check` workflow was inherited from `apache/nuttx-apps` with hard-coded `repository: apache/nuttx` and `repository: apache/nuttx-apps` in the checkout steps. The original intent was to align with `apache` community check rules, but since `open-vela` has diverged from upstream and hasn't kept the script in sync, the `base.sha` in every PR refers to a commit that does not exist in `apache` repos, causing the workflow to abort:

```
fatal: Invalid revision range <open-vela-sha>..HEAD
Process completed with exit code 128.
```

This affects every PR opened against `open-vela/nuttx-apps@dev-ai-contest-2026`.

## Fix

Point the `nuttx` checkout to `open-vela/nuttx` and remove the hard-coded `repository: apache/nuttx-apps` (defaults to the current repository on a `pull_request` event):

```diff
       - name: Checkout nuttx repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx
+          repository: open-vela/nuttx
           path: nuttx
           fetch-depth: 0

       - name: Checkout apps repo
         uses: actions/checkout@v4
         with:
-          repository: apache/nuttx-apps
           path: apps
           fetch-depth: 0
```

This is identical to the change being applied on the `dev` branch via [open-vela/nuttx-apps#106](https://github.com/open-vela/nuttx-apps/pull/106).

## Impact

- **Is new feature added?** NO — CI workflow correctness fix.
- **Impact on user?** NO.
- **Impact on build?** NO — only the Check workflow.
- **Impact on hardware?** NO.
- **Impact on documentation?** NO.
- **Impact on security?** NO — the workflow now fetches from `open-vela`'s own repos rather than from `apache/*`.
- **Impact on compatibility?** NO.

## Reference

- Companion PR on `dev` branch: [open-vela/nuttx-apps#106](https://github.com/open-vela/nuttx-apps/pull/106)
- Companion PR on `open-vela/nuttx@dev-ai-contest-2026`: [open-vela/nuttx#295](https://github.com/open-vela/nuttx/pull/295) (and on `dev`: [open-vela/nuttx#296](https://github.com/open-vela/nuttx/pull/296))
- Affected open-vela PRs e.g. `nuttx#292` had the same `check` failure pattern.

## PR verification Self-Check

- [x] This PR introduces only one functional change.
- [x] I have updated all required description fields above.
- [x] My PR adheres to Contributing Guidelines and Documentation.
- [ ] My PR is still work in progress (not ready for review).
- [x] My PR is ready for review and can be safely merged into a codebase.
