### PR TITLE
graphics/lvgl: exclude platform-specific draw backends from GLOB

### DIFF
--- a/graphics/lvgl/CMakeLists.txt
+++ b/graphics/lvgl/CMakeLists.txt
@@ -68,6 +68,41 @@ if(CONFIG_GRAPHICS_LVGL)
     "${LVGL_DIR}/src/*.cpp"
     "${LVGL_DIR}/demos/*.c"
     "${LVGL_DIR}/examples/*.c")
+
+  # GLOB_RECURSE above blindly pulls every source file under src/, including
+  # hardware-accelerated draw backends and arch-specific asm that only build on
+  # specific platforms. Filter them out when the corresponding Kconfig option is
+  # not set, so unrelated targets don't try to compile them.
+
+  # blend/neon/*.S is ARMv7 (AArch32) inline asm and only assembles under an ARM
+  # 32-bit / M-profile / R-profile toolchain.
+  if(NOT CONFIG_ARCH_ARMV7A
+     AND NOT CONFIG_ARCH_ARMV7M
+     AND NOT CONFIG_ARCH_ARMV8M
+     AND NOT CONFIG_ARCH_ARMV7R
+     AND NOT CONFIG_ARCH_ARMV8R)
+    list(FILTER SRCS EXCLUDE REGEX "/blend/neon/.*\\.S$")
+  endif()
+
+  # Allwinner G2D backend; needs g2d_driver.h and hal_cache.h from the Allwinner
+  # BSP, absent on non-Allwinner targets.
+  if(NOT CONFIG_LV_USE_DRAW_G2D)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/sunxi_g2d/.*\\.(c|cpp)$")
+  endif()
+
+  # VeriSilicon VG-Lite backend.
+  if(NOT CONFIG_LV_USE_DRAW_VG_LITE)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/vg_lite/.*\\.(c|cpp)$")
+    list(FILTER SRCS EXCLUDE REGEX
+         "/draw/vg_lite_vector_optimize/.*\\.(c|cpp)$")
+  endif()
+
+  # NXP i.MX RT VG-Lite / PXP backends.
+  if(NOT CONFIG_LV_USE_DRAW_VGLITE)
+    list(FILTER SRCS EXCLUDE REGEX "/draw/nxp/vglite/.*\\.(c|cpp)$")
+    list(FILTER SRCS EXCLUDE REGEX "/draw/nxp/pxp/.*\\.(c|cpp)$")
+  endif()
+
   nuttx_add_library(lvgl)
 
   target_sources(lvgl PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

Filter LVGL's `GLOB_RECURSE` source list so that ARMv7-only asm and hardware-accelerated draw backends (Sunxi G2D, VG-Lite, NXP PXP/VGLite) are only compiled when they actually apply to the current target.

## Background

`apps/graphics/lvgl/CMakeLists.txt` currently collects LVGL sources with

```cmake
file(GLOB_RECURSE SRCS
     "${LVGL_DIR}/src/*.S"
     "${LVGL_DIR}/src/*.c"
     "${LVGL_DIR}/src/*.cpp"
     ...)
```

This unconditionally picks up every file under `lvgl/src/`, including hardware-accelerated draw backends and arch-specific inline asm, regardless of whether the current target actually enables them or has the underlying vendor headers.

Concretely, this breaks non-ARMv7 builds of any board that enables `CONFIG_GRAPHICS_LVGL=y` (goldfish-arm64, qemu-armeabi-v7a, sim, various STM32 boards, etc.):

1. **`src/draw/sw/blend/neon/lv_blend_neon.S`** is ARMv7 (AArch32) assembly. It uses `r0`-`r15` register names, `cpsr`, and `pop {r4-r11, pc}`, none of which exist in the AArch64 assembler. Building goldfish-arm64:
   ```
   Error: expected a register or register list at operand 1
     -- `add SRC_ADDR,SRC_ADDR,SRC_STRIDE'
   Error: unknown mnemonic `pop' -- `pop {r4-r11,pc}'
   ```

2. **`src/draw/sunxi_g2d/*.c`** include `<g2d_driver.h>` and `<hal_cache.h>`, which only exist in the Allwinner BSP. On any non-Allwinner target:
   ```
   fatal error: g2d_driver.h: No such file or directory
   ```

3. **`src/draw/vg_lite/*`**, **`src/draw/nxp/vglite/*`**, **`src/draw/nxp/pxp/*`** have the same class of issue — they need vendor-supplied GPU headers that are not present on generic simulator/QEMU targets.

The Kconfig options that gate these backends already exist:

- `LV_DRAW_SW_ASM_NEON` — implicitly requires an ARM subset (its own Kconfig depends on the ARM archs).
- `LV_USE_DRAW_G2D` — already used later in this file for `target_include_directories` and `target_link_libraries`.
- `LV_USE_DRAW_VG_LITE`, `LV_USE_DRAW_VGLITE` — same.

The `GLOB_RECURSE` layer just wasn't consulting them.

## Features

- Filter `SRCS` after `GLOB_RECURSE` using `list(FILTER ... EXCLUDE REGEX ...)`.
- Exclude `blend/neon/*.S` unless building for ARMv7-A / ARMv7-M / ARMv7-R / ARMv8-M / ARMv8-R.
- Exclude `draw/sunxi_g2d/*.c` unless `CONFIG_LV_USE_DRAW_G2D` is set.
- Exclude `draw/vg_lite/*` and `draw/vg_lite_vector_optimize/*` unless `CONFIG_LV_USE_DRAW_VG_LITE` is set.
- Exclude `draw/nxp/vglite/*` and `draw/nxp/pxp/*` unless `CONFIG_LV_USE_DRAW_VGLITE` is set.
- Comment block explains each exclusion so a future reader knows why the filter exists.

## Files

| File | Change |
|------|--------|
| `graphics/lvgl/CMakeLists.txt` | Add `list(FILTER SRCS EXCLUDE REGEX ...)` block after the `GLOB_RECURSE` |

## Testing

Verified on `openvela/dev-ai-contest-2026` @ `4a914a221` (openvela/nuttx-apps) + `a6defdb4255` (openvela/nuttx):

1. **Goldfish arm64** — `./build.sh vendor/openvela/boards/vela/configs/goldfish-arm64-v8a-ap --cmake -j16` succeeds (previously failed at `lv_blend_neon.S` and `lv_g2d_utils.h`).
2. **Goldfish arm64 + ai_agent defconfig** — installing `packages/ai_agent/defconfigs/goldfish-arm64-v8a-ap/goldfish-arm64-v8a-ap_defconfig` and building succeeds (~6m53s), produces `vela_ap.elf`/`vela_ap.bin`, and QEMU boots to `NuttShell (NSH)` with `adbd` running.
3. **No regression on ARMv7** — `./build.sh vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-ap --cmake -j16` still compiles `lv_blend_neon.S` (the ARMv7 arch condition permits it).
4. **Semantics unchanged for enabled features** — when a board actually sets `CONFIG_LV_USE_DRAW_G2D=y` or `CONFIG_LV_USE_DRAW_VG_LITE=y`, the corresponding sources are still picked up by the GLOB and pass the filter.

## Notes

- All exclusion regexes match on **relative sub-path** (`/blend/neon/`, `/draw/sunxi_g2d/`, ...) so they cannot accidentally match a shared/common source that happens to have "neon" or "g2d" in its filename.
- Chose to filter the GLOB output rather than switch to explicit `list(APPEND SRCS ...)` — smaller diff and matches the existing style of this CMakeLists.txt.
- This is complementary to (and independent of) the upstream `nuttx` PR that adds stale-artifact detection to `nuttx/CMakeLists.txt`. Either PR alone helps; both together are strictly better.