### PR TITLE
fix: reacquire IPv4 after carrier changes

### DIFF
--- a/netutils/netinit/Kconfig
+++ b/netutils/netinit/Kconfig
@@ -106,6 +106,30 @@ config NETINIT_RETRYMSEC
 
 endif # NETINIT_MONITOR
 
+config NETINIT_CARRIER_POLL
+	bool "Monitor carrier state by polling"
+	default n
+	depends on NET_ETHERNET && NET_IPv4 && NET_UDP && !NETINIT_MONITOR
+	---help---
+		Keep the network initialization thread alive and poll IFF_RUNNING.
+		On carrier loss, clear the active IPv4 configuration without taking
+		the interface administratively down.  On carrier recovery, obtain a
+		new DHCP lease when NETINIT_DHCPC is selected.
+
+if NETINIT_CARRIER_POLL
+
+config NETINIT_CARRIER_POLL_MSEC
+	int "Carrier polling period (msec)"
+	default 500
+	range 100 60000
+
+config NETINIT_DHCP_RETRYMSEC
+	int "DHCP retry period while carrier is present (msec)"
+	default 5000
+	range 1000 300000
+
+endif # NETINIT_CARRIER_POLL
+
 config NETINIT_THREAD_STACKSIZE
 	int "Network initialization thread stack size"
 	default DEFAULT_TASK_STACKSIZE

--- a/netutils/netinit/netinit.c
+++ b/netutils/netinit/netinit.c
@@ -970,6 +970,123 @@ errout:
 #endif
 
 /****************************************************************************
+ * Name: netinit_clear_ipv4
+ *
+ * Description:
+ *   Remove active IPv4 configuration after carrier loss without changing
+ *   the administrative interface state.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_NETINIT_CARRIER_POLL) && defined(CONFIG_NET_IPv4)
+static void netinit_clear_ipv4(void)
+{
+  struct in_addr addr;
+
+  addr.s_addr = INADDR_ANY;
+  netlib_set_dripv4addr(NET_DEVNAME, &addr);
+  netlib_set_ipv4netmask(NET_DEVNAME, &addr);
+  netlib_set_ipv4addr(NET_DEVNAME, &addr);
+}
+
+/****************************************************************************
+ * Name: netinit_carrier_monitor
+ *
+ * Description:
+ *   Follow driver-published carrier edges while preserving IFF_UP.
+ *
+ ****************************************************************************/
+
+static int netinit_carrier_monitor(void)
+{
+  struct in_addr addr;
+  struct ifreq ifr;
+  unsigned int retry_msec = 0;
+  bool last_running = false;
+  bool initialized = false;
+  bool running;
+  int ret;
+  int sd;
+
+  sd = socket(NET_SOCK_FAMILY, NET_SOCK_TYPE, NET_SOCK_PROTOCOL);
+  if (sd < 0)
+    {
+      ret = -errno;
+      nerr("ERROR: Failed to create carrier monitor socket: %d\n", ret);
+      return ret;
+    }
+
+  for (; ; )
+    {
+      memset(&ifr, 0, sizeof(ifr));
+      strlcpy(ifr.ifr_name, NET_DEVNAME, IFNAMSIZ);
+      ret = ioctl(sd, SIOCGIFFLAGS, (unsigned long)&ifr);
+      if (ret < 0)
+        {
+          nerr("ERROR: Failed to read interface flags: %d\n", errno);
+          goto wait;
+        }
+
+      running = (ifr.ifr_flags & IFF_RUNNING) != 0;
+      if (!initialized || running != last_running)
+        {
+          ninfo("%s carrier %s\n", NET_DEVNAME,
+                running ? "up" : "down");
+
+          if (!running)
+            {
+              netinit_clear_ipv4();
+              retry_msec = 0;
+            }
+#ifdef CONFIG_NETUTILS_DHCPC
+          else if (g_use_dhcpc)
+            {
+              addr.s_addr = INADDR_ANY;
+              netlib_get_ipv4addr(NET_DEVNAME, &addr);
+              if (addr.s_addr == INADDR_ANY &&
+                  netlib_obtain_ipv4addr(NET_DEVNAME) < 0)
+                {
+                  retry_msec = CONFIG_NETINIT_DHCP_RETRYMSEC;
+                }
+            }
+#endif
+
+          last_running = running;
+          initialized = true;
+        }
+#ifdef CONFIG_NETUTILS_DHCPC
+      else if (running && g_use_dhcpc)
+        {
+          addr.s_addr = INADDR_ANY;
+          netlib_get_ipv4addr(NET_DEVNAME, &addr);
+          if (addr.s_addr == INADDR_ANY)
+            {
+              if (retry_msec <= CONFIG_NETINIT_CARRIER_POLL_MSEC)
+                {
+                  if (netlib_obtain_ipv4addr(NET_DEVNAME) < 0)
+                    {
+                      retry_msec = CONFIG_NETINIT_DHCP_RETRYMSEC;
+                    }
+                }
+              else
+                {
+                  retry_msec -= CONFIG_NETINIT_CARRIER_POLL_MSEC;
+                }
+            }
+          else
+            {
+              retry_msec = 0;
+            }
+        }
+#endif
+
+wait:
+      usleep(CONFIG_NETINIT_CARRIER_POLL_MSEC * 1000);
+    }
+}
+#endif
+
+/****************************************************************************
  * Name: netinit_thread
  *
  * Description:
@@ -990,6 +1107,12 @@ static pthread_addr_t netinit_thread(pthread_addr_t arg)
   /* Monitor the network status */
 
   netinit_monitor();
+#endif
+
+#ifdef CONFIG_NETINIT_CARRIER_POLL
+  /* Monitor driver-published carrier state without changing IFF_UP. */
+
+  netinit_carrier_monitor();
 #endif
 
   ninfo("Exit\n");

--- a/netutils/netlib/netlib_setdripv4addr.c
+++ b/netutils/netlib/netlib_setdripv4addr.c
@@ -111,10 +111,13 @@ int netlib_set_dripv4addr(FAR const char *ifname,
 
               delroute(sockfd, &target, &netmask, sizeof(target));
 
-              /* Then add the new default route */
+              /* Then add the new default route unless zero means clear. */
 
-              ret = addroute(sockfd, &target, &netmask,
-                             &router, sizeof(router));
+              if (addr->s_addr != INADDR_ANY)
+                {
+                  ret = addroute(sockfd, &target, &netmask,
+                                 &router, sizeof(router));
+                }
             }
 #endif
 


### PR DESCRIPTION
## Summary

Add an opt-in netinit carrier polling mode that follows driver-published `IFF_RUNNING` changes while preserving the interface's administrative `IFF_UP` state. Carrier loss clears stale IPv4 configuration, and carrier recovery obtains or retries DHCP automatically.

## Features

- Add `CONFIG_NETINIT_CARRIER_POLL` with configurable carrier and DHCP retry periods.
- Clear the active IPv4 address, netmask, and default route after carrier loss.
- Obtain a new DHCP lease after carrier recovery without requiring a manual `renew`.
- Treat a zero router address as a request to remove the existing default route without adding a zero-gateway route.

## Files

| File | Description |
|------|-------------|
| `netutils/netinit/Kconfig` | Adds opt-in carrier polling and retry interval settings. |
| `netutils/netinit/netinit.c` | Monitors carrier state and manages IPv4/DHCP transitions. |
| `netutils/netlib/netlib_setdripv4addr.c` | Allows callers to clear the default route with `INADDR_ANY`. |

## Impact

The new behavior is disabled by default and is limited to IPv4 Ethernet configurations that explicitly select `NETINIT_CARRIER_POLL`. Existing one-shot initialization and `NETINIT_MONITOR` behavior are unchanged.

## Testing

- Built the STM32H750B-DK VelaGuard QSPI configuration successfully.
- Passed `git diff --check` and NuttX `checkpatch.sh`.
- Programmed and verified the MB1381 H750XB-B01 target.
- Verified cable loss leaves the interface `UP` but not `RUNNING`, with IPv4/router/netmask cleared to `0.0.0.0`.
- Completed three unplug/replug cycles with automatic DHCP recovery and bidirectional ping restored with zero packet loss.

Related: https://github.com/open-vela/nuttx/pull/323